### PR TITLE
Fix t/smartmatch.t for Perl 5.8

### DIFF
--- a/t/smartmatch.t
+++ b/t/smartmatch.t
@@ -1,6 +1,8 @@
 use strict;
 use Test::More;
-plan skip_all => "~~ support requires v5.10.1" unless $] >= 5.010001;
+BEGIN {
+    plan skip_all => "~~ support requires v5.10.1" unless $] >= 5.010001;
+}
 
 plan tests => 16;
 


### PR DESCRIPTION
Currently, t/smartmatch.t fails on 5.8, because the file fails to parse as valid Perl.  This pull request patches the test to skip all tests in a BEGIN block so it doesn't fail to install on 5.8.
