### PR TITLE
Base: simplify declaration of ~~ overload

### DIFF
--- a/lib/Syntax/Keyword/Junction/Base.pm
+++ b/lib/Syntax/Keyword/Junction/Base.pm
@@ -20,9 +20,9 @@ use overload(
     'lt'   => "str_lt",
     'bool' => "bool",
     '""'   => sub {shift},
+    $] >= 5.010001 ? ('~~' => 'match') : (),
 );
 
-use if ($] >= 5.010001), overload => '~~' => 'match';
 
 sub new { bless \@_, shift }
 


### PR DESCRIPTION
For `Syntax::Keyword::Junction::Base`, here is a simplification of the overload of `~~`. `use if` is overkill here.
