### PR TITLE
"use base" -> "use parent"

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 requires 'Sub::Exporter::Progressive' => 0.001006;
 requires 'syntax';
+requires 'parent';   # for perl < 5.10.1
 
 on test => sub {
    requires 'Test::More' => 0.88;

--- a/lib/Syntax/Keyword/Junction/All.pm
+++ b/lib/Syntax/Keyword/Junction/All.pm
@@ -5,7 +5,7 @@ use warnings;
 
 # VERSION
 
-use base 'Syntax::Keyword::Junction::Base';
+use parent 'Syntax::Keyword::Junction::Base';
 
 BEGIN {
   if ($] >= 5.010001) {

--- a/lib/Syntax/Keyword/Junction/Any.pm
+++ b/lib/Syntax/Keyword/Junction/Any.pm
@@ -5,7 +5,7 @@ use warnings;
 
 # VERSION
 
-use base 'Syntax::Keyword::Junction::Base';
+use parent 'Syntax::Keyword::Junction::Base';
 
 BEGIN {
   if ($] >= 5.010001) {

--- a/lib/Syntax/Keyword/Junction/None.pm
+++ b/lib/Syntax/Keyword/Junction/None.pm
@@ -5,7 +5,7 @@ use warnings;
 
 # VERSION
 
-use base 'Syntax::Keyword::Junction::Base';
+use parent 'Syntax::Keyword::Junction::Base';
 
 BEGIN {
   if ($] >= 5.010001) {

--- a/lib/Syntax/Keyword/Junction/One.pm
+++ b/lib/Syntax/Keyword/Junction/One.pm
@@ -5,7 +5,7 @@ use warnings;
 
 # VERSION
 
-use base 'Syntax::Keyword::Junction::Base';
+use parent 'Syntax::Keyword::Junction::Base';
 
 BEGIN {
   if ($] >= 5.010001) {


### PR DESCRIPTION
From http://perldoc.perl.org/parent.html#HISTORY :

> This module was forked from base to remove the cruft that had accumulated in it.
