### PR TITLE
Add missing test requirement: Test::Pod

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,5 +5,6 @@ requires 'parent';   # for perl < 5.10.1
 on test => sub {
    requires 'Test::More' => 0.88;
    requires 'Test::Requires' => 0.07;
+   requires 'Test::Pod' => 0;
 };
 


### PR DESCRIPTION
CPANTS noticed that this module was missing from the list of test
requirements; this change thus keeps the list of requirements up to
date.

If you want a minimum `Test::Pod` version set in the requirements, just let me know and I'll update the PR and resubmit.