### PR TITLE
Declare required minimum Perl version

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 requires 'Sub::Exporter::Progressive' => 0.001006;
 requires 'syntax';
 requires 'parent';   # for perl < 5.10.1
+requires 'perl' => "5.006";
 
 on test => sub {
    requires 'Test::More' => 0.88;

--- a/lib/Syntax/Keyword/Junction.pm
+++ b/lib/Syntax/Keyword/Junction.pm
@@ -2,6 +2,7 @@ package Syntax::Keyword::Junction;
 
 use strict;
 use warnings;
+use 5.006;
 
 # VERSION
 


### PR DESCRIPTION
Although the smartmatch tests require at least Perl 5.10, the main
modules require only Perl 5.6, hence the required version set in the
metadata is set to the lower version requirement.

I tried specifying Perl 5.10 as the required version in the test requirements in the `cpanfile`, unfortunately, this value then overrode the required minimum Perl version for the runtime requirements, hence I kept the minimum version at 5.6 since people should be able to install and use the module successfully with this version.