### PR TITLE
Add "provides" info to dist metadata

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -15,3 +15,4 @@ version          = 0.003008
 [ReadmeFromPod]
 [PodSyntaxTests]
 [Prereqs::FromCPANfile]
+[MetaProvides::Package]


### PR DESCRIPTION
CPANTS noticed that information about the modules that this dist provides was missing from the dist's metadata.  This PR uses the `MetaProvides::Package` dzil plugin to automatically generate this extra information.  If you'd like this pull request changed in any way, just let me know and I'll update it and resubmit as necessary.