### PR TITLE
Ignore the cover_db dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
+cover_db/
 Syntax-Keyword-Junction-*


### PR DESCRIPTION
... since it's automatically generated by `cover` and doesn't need to be
added to the repo or be shown in the `git status` output.