### PR TITLE
Use Devel::Cover 1.23 when testing Perl 5.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
 install:
    - export RELEASE_TESTING=1 AUTOMATED_TESTING=1 AUTHOR_TESTING=1 HARNESS_OPTIONS=c HARNESS_TIMER=1
    - cpanm --quiet --notest Sub::Exporter
+   - if [ "$PERLBREW_PERL" = "5.8" ]; then cpanm --quiet --notest Devel::Cover~"<=1.23"; fi
    - cpanm --quiet --notest Devel::Cover::Report::Coveralls
    - cpanm --quiet --notest --installdeps .
 


### PR DESCRIPTION
... since this is the last version to support Perl 5.8.  I'd noticed that the Travis builds were failing on Perl 5.8 and decided to work out why and fix the issue.  It turns out that Devel::Cover 1.23 is the last version to support Perl 5.8, hence I've set the Travis tests to install this version of Devel::Cover if Perl 5.8 is being used.  This patch thus stops the coverage tests from failing on Travis.