### PR TITLE
Quieten perlcritic's stringy eval warnings

### DIFF
--- a/lib/Syntax/Keyword/Junction/All.pm
+++ b/lib/Syntax/Keyword/Junction/All.pm
@@ -9,6 +9,7 @@ use parent 'Syntax::Keyword::Junction::Base';
 
 BEGIN {
   if ($] >= 5.010001) {
+    ## no critic
     eval q|
 sub match {
     my ( $self, $other, $is_rhs ) = @_;

--- a/lib/Syntax/Keyword/Junction/Any.pm
+++ b/lib/Syntax/Keyword/Junction/Any.pm
@@ -9,6 +9,7 @@ use parent 'Syntax::Keyword::Junction::Base';
 
 BEGIN {
   if ($] >= 5.010001) {
+    ## no critic
     eval q|
 sub match {
     no if $] > 5.017010, warnings => 'experimental::smartmatch';

--- a/lib/Syntax/Keyword/Junction/None.pm
+++ b/lib/Syntax/Keyword/Junction/None.pm
@@ -9,6 +9,7 @@ use parent 'Syntax::Keyword::Junction::Base';
 
 BEGIN {
   if ($] >= 5.010001) {
+    ## no critic
     eval q|
 sub match {
     no if $] > 5.017010, warnings => 'experimental::smartmatch';

--- a/lib/Syntax/Keyword/Junction/One.pm
+++ b/lib/Syntax/Keyword/Junction/One.pm
@@ -9,6 +9,7 @@ use parent 'Syntax::Keyword::Junction::Base';
 
 BEGIN {
   if ($] >= 5.010001) {
+    ## no critic
     eval q|
 sub match {
     no if $] > 5.017010, warnings => 'experimental::smartmatch';


### PR DESCRIPTION
... since in this case the use of string eval is intentional and hence
it isn't helpful for perlcritic to flag these instances as being
problematic.

If you need anything changed in this PR, please let me know and I'll be happy to update and resubmit as appropriate.