### PR TITLE
Remove ambiguity in input/limits comparison example

### DIFF
--- a/lib/Syntax/Keyword/Junction.pm
+++ b/lib/Syntax/Keyword/Junction.pm
@@ -47,7 +47,7 @@ __END__
     ...
   }
 
-  if (all(@input) <= @limits) {
+  if (all(@input) <= scalar @limits) {
     ...
   }
 


### PR DESCRIPTION
As mentioned in GitHub issue #10, the input/limits comparison example in
the documentation is ambiguous; it could be interpreted as "compare each
element of `@input` with each element of `@limits` and return the `all`
junction of the comparisons".  However this isn't the case, for instance:

```
use strict;
use warnings;

use Syntax::Keyword::Junction qw( all );

my @input = (1, 2, 3, 4, 5, 6);
my @limits = (4, 4, 4, 4, 4, 4);

if (all(@input) <= scalar @limits) {
    print "all input less than or equal to limits\n";
}
else {
    print "not all input less than or equal to limits\n";
}
```

prints "all input less than or equal to limits", but the last two
elements of the `@input` array are greater than the limits.  However,
the input elements are all less than or equal to the length of the
`@limits` array.  If one reduces the length of the `@limits` array, then
the code above prints "not all input less than or equal to limits".
This is the same behaviour as in Perl6 (from the REPL):

```
> all(1, 2, 3, 4, 5, 6) <= (4, 4, 4, 4, 4, 4)
all(True, True, True, True, True, True)
> all(1, 2, 3, 4, 5, 6) <= (4, 4, 4, 4, 4)
all(True, True, True, True, True, False)
```

Consequently, adding the `scalar` keyword in the example makes this
behaviour more obvious.

This PR would fix the issue raised in #10.